### PR TITLE
Reuse browser for login

### DIFF
--- a/src/services/browserService.ts
+++ b/src/services/browserService.ts
@@ -32,6 +32,10 @@ export class BrowserService {
     return BrowserService.instance;
   }
 
+  public static getInstance(): BrowserService | null {
+    return BrowserService.instance;
+  }
+
   /**
    * Get whether debug mode is enabled
    */
@@ -162,6 +166,10 @@ export class BrowserService {
     });
   }
 
+  public async getBrowser(): Promise<Browser | null> {
+    return this.browser;
+  }
+
   /**
    * Get or create a browser instance
    */
@@ -248,18 +256,12 @@ export class BrowserService {
   /**
    * Clean up resources
    */
-  public async cleanup(browser: Browser | null, page: Page | null): Promise<void> {
-    if (!this.isDebugMode) {
-      if (page) {
-        await page
-          .close()
-          .catch((e) => logger.error(`Failed to close page: ${e.message}`));
-      }
-      if (browser) {
-        await browser
-          .close()
-          .catch((e) => logger.error(`Failed to close browser: ${e.message}`));
-      }
+  public async cleanup(): Promise<void> {
+    if (this.browser) {
+      await this.browser.close().catch((e) => logger.error(`Failed to close browser: ${e.message}`));
+      this.browser = null;
     }
+    BrowserService.instance = null;
+    return;
   }
 }

--- a/src/services/browserService.ts
+++ b/src/services/browserService.ts
@@ -200,6 +200,17 @@ export class BrowserService {
   }
 
   /**
+   * Cloase a page
+   */
+  public async closePage(page: Page | null): Promise<void> {
+    if (page) {
+      await page
+        .close()
+        .catch((e) =>  logger.error(`Failed to close page: ${e.message}`));
+    }
+  }
+
+  /**
    * Clean up resources
    */
   public async cleanup(browser: Browser | null, page: Page | null): Promise<void> {

--- a/src/services/browserService.ts
+++ b/src/services/browserService.ts
@@ -11,8 +11,9 @@ export class BrowserService {
   private browser: Browser | null = null;
   private context: BrowserContext | null = null;
   private viewport: {width: number, height: number} | null = null;
+  private static instance: BrowserService | null = null;
 
-  constructor(options: FetchOptions) {
+  private constructor(options: FetchOptions) {
     this.options = options;
     this.isDebugMode = process.argv.includes("--debug");
 
@@ -20,6 +21,15 @@ export class BrowserService {
     if (options.debug !== undefined) {
       this.isDebugMode = options.debug;
     }
+
+    BrowserService.instance = this;
+  }
+
+  public static createOrGetInstance(options: FetchOptions): BrowserService {
+    if (!BrowserService.instance) {
+      BrowserService.instance = new BrowserService(options);
+    }
+    return BrowserService.instance;
   }
 
   /**

--- a/src/tools/closeBrowser.ts
+++ b/src/tools/closeBrowser.ts
@@ -1,0 +1,27 @@
+import { BrowserService } from "../services/browserService.js";
+import { logger } from "../utils/logger.js";
+
+export const closeBrowserTool = {
+  name: "close_browser",
+  description: "Close the browser instance and clean up resources",
+  inputSchema: {
+    type: "object",
+    properties: {},
+    required: [],
+  },
+};
+
+export async function closeBrowser(args: any) {
+  logger.debug("Closing browser...");
+
+  // Get the singleton browser service instance
+  const browserService = await BrowserService.getInstance();
+
+  if (!browserService) {
+    return { content: [{ type: "text", text: "No active browser instance found." }] };
+  }
+
+  await browserService.cleanup();
+
+  return { content: [{ type: "text", text: "Browser closed successfully." }] };
+}

--- a/src/tools/fetchUrl.ts
+++ b/src/tools/fetchUrl.ts
@@ -75,9 +75,6 @@ export const fetchUrlTool = {
 /**
  * Implementation of the fetch_url tool
  */
-
-let browserService: BrowserService | null = null;
-
 export async function fetchUrl(args: any) {
   const url = String(args?.url || "");
   if (!url) {
@@ -103,7 +100,7 @@ export async function fetchUrl(args: any) {
   };
 
   // Create browser service
-  browserService = browserService ?? new BrowserService(options);
+  const browserService = BrowserService.createOrGetInstance(options);
 
   // Create content processor
   const processor = new WebContentProcessor(options, "[FetchURL]");

--- a/src/tools/fetchUrls.ts
+++ b/src/tools/fetchUrls.ts
@@ -78,8 +78,6 @@ export const fetchUrlsTool = {
 /**
  * Implementation of the fetch_urls tool
  */
-let browserService: BrowserService | null = null;
-
 export async function fetchUrls(args: any) {
   const urls = (args?.urls as string[]) || [];
   if (!urls || !Array.isArray(urls) || urls.length === 0) {
@@ -104,7 +102,7 @@ export async function fetchUrls(args: any) {
   };
 
   // Create browser service
-  browserService = browserService ?? new BrowserService(options);
+  const browserService = BrowserService.createOrGetInstance(options);
 
   if (browserService.isInDebugMode()) {
     logger.debug(`Debug mode enabled for URLs: ${urls.join(", ")}`);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,14 +1,17 @@
 import { fetchUrlTool, fetchUrl } from './fetchUrl.js';
 import { fetchUrlsTool, fetchUrls } from './fetchUrls.js';
+import { closeBrowserTool, closeBrowser } from './closeBrowser.js';
 
 // Export tool definitions
 export const tools = [
   fetchUrlTool,
-  fetchUrlsTool
+  fetchUrlsTool,
+  closeBrowserTool
 ];
 
 // Export tool implementations
 export const toolHandlers = {
   [fetchUrlTool.name]: fetchUrl,
-  [fetchUrlsTool.name]: fetchUrls
+  [fetchUrlsTool.name]: fetchUrls,
+  [closeBrowserTool.name]: closeBrowser
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,8 +8,9 @@ export interface FetchOptions {
     navigationTimeout: number;
     disableMedia: boolean;
     debug?: boolean;
+    closePage?: boolean;
   }
-  
+
   export interface FetchResult {
     success: boolean;
     content: string;


### PR DESCRIPTION
* I added `closePage` field to `fetch_url/fetch_urls` tools scheme. This filed enable browser keep page open for log-in. This feature runs on debug mode.
* I added `close_browser` tool due to modifications on above, browser can't close after each call of tools. we can close browser at any time.